### PR TITLE
feat(agent): I3 — cancel task with sandbox stop and UI polish

### DIFF
--- a/e2e/cancel-task.spec.ts
+++ b/e2e/cancel-task.spec.ts
@@ -1,0 +1,309 @@
+/**
+ * E2E tests for the Cancel Task feature (I3).
+ *
+ * Tests:
+ *   1. Create issue, assign agent, wait for task to start, click Stop, verify cancelled
+ *   2. Cancel on already-completed task is a no-op (no error)
+ *
+ * Prerequisites:
+ *   - Backend running (make start)
+ *   - Frontend running (pnpm dev:web)
+ *   - Daemon running with DAYTONA_API_KEY exported
+ */
+
+import { test, expect } from "@playwright/test";
+import { TestApiClient } from "./fixtures";
+import { loginAsDefault, createTestApi } from "./helpers";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ??
+  `http://localhost:${process.env.PORT ?? "8080"}`;
+
+// -- Helpers (mirrored from embedded-agent.spec.ts) ---------------------------
+
+interface Runtime {
+  id: string;
+  name: string;
+  provider: string;
+  status: string;
+}
+interface Agent {
+  id: string;
+  name: string;
+  runtime_id: string;
+}
+interface AgentTask {
+  id: string;
+  status: string;
+  issue_id: string;
+}
+
+async function apiFetch(
+  token: string,
+  wsId: string,
+  path: string,
+  init?: RequestInit,
+) {
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "X-Workspace-ID": wsId,
+      ...((init?.headers as Record<string, string>) ?? {}),
+    },
+  });
+}
+
+async function listRuntimes(token: string, wsId: string): Promise<Runtime[]> {
+  const res = await apiFetch(token, wsId, "/api/runtimes");
+  if (!res.ok) throw new Error(`listRuntimes: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+async function findEmbeddedRuntime(
+  token: string,
+  wsId: string,
+): Promise<Runtime | undefined> {
+  const runtimes = await listRuntimes(token, wsId);
+  return runtimes.find(
+    (r) => r.provider === "embedded" && r.status === "online",
+  );
+}
+
+async function createAgent(
+  token: string,
+  wsId: string,
+  name: string,
+  runtimeId: string,
+): Promise<Agent> {
+  const res = await apiFetch(token, wsId, "/api/agents", {
+    method: "POST",
+    body: JSON.stringify({ name, runtime_id: runtimeId, visibility: "workspace" }),
+  });
+  if (!res.ok) throw new Error(`createAgent: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+async function assignIssueToAgent(
+  token: string,
+  wsId: string,
+  issueId: string,
+  agentId: string,
+) {
+  const res = await apiFetch(token, wsId, `/api/issues/${issueId}`, {
+    method: "PUT",
+    body: JSON.stringify({ assignee_type: "agent", assignee_id: agentId }),
+  });
+  if (!res.ok) throw new Error(`assignIssue: ${res.status}`);
+  return res.json();
+}
+
+async function listTasksByIssue(
+  token: string,
+  wsId: string,
+  issueId: string,
+): Promise<AgentTask[]> {
+  const res = await apiFetch(token, wsId, `/api/issues/${issueId}/task-runs`);
+  if (!res.ok) throw new Error(`listTasksByIssue: ${res.status} ${await res.text()}`);
+  const data = await res.json();
+  return Array.isArray(data) ? data : data.tasks ?? data.runs ?? [];
+}
+
+async function cancelTaskViaApi(
+  token: string,
+  wsId: string,
+  issueId: string,
+  taskId: string,
+): Promise<Response> {
+  return apiFetch(token, wsId, `/api/issues/${issueId}/tasks/${taskId}/cancel`, {
+    method: "POST",
+  });
+}
+
+async function deleteAgent(token: string, wsId: string, agentId: string) {
+  await apiFetch(token, wsId, `/api/agents/${agentId}/archive`, { method: "POST" });
+}
+
+async function pollUntil<T>(
+  fn: () => Promise<T>,
+  predicate: (result: T) => boolean,
+  timeoutMs = 120_000,
+  intervalMs = 2_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (predicate(result)) return result;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+}
+
+// -- Test Suite ---------------------------------------------------------------
+
+test.describe("Cancel Task (I3)", () => {
+  let api: TestApiClient;
+  let token: string;
+  let wsId: string;
+  let embeddedRuntime: Runtime;
+  let createdAgentIds: string[] = [];
+
+  test.beforeEach(async () => {
+    api = await createTestApi();
+    token = api.getToken()!;
+
+    const workspaces = await api.getWorkspaces();
+    if (workspaces.length === 0) throw new Error("No workspace found");
+
+    let runtime: Runtime | undefined;
+    for (const ws of workspaces) {
+      try {
+        runtime = await findEmbeddedRuntime(token, ws.id);
+      } catch {
+        continue;
+      }
+      if (runtime) {
+        wsId = ws.id;
+        break;
+      }
+    }
+
+    if (!runtime || !wsId) {
+      test.skip(true, "No embedded runtime (daemon not running with DAYTONA_API_KEY)");
+      return;
+    }
+    embeddedRuntime = runtime;
+    api.setWorkspaceId(wsId);
+    createdAgentIds = [];
+  });
+
+  test.afterEach(async () => {
+    if (token && wsId) {
+      for (const id of createdAgentIds) {
+        try { await deleteAgent(token, wsId, id); } catch { /* ignore */ }
+      }
+    }
+    if (api) await api.cleanup();
+  });
+
+  // -- 1. Cancel a running task via the Stop button in the UI -----------------
+
+  test("cancel running task via Stop button in UI", async ({ page }) => {
+    test.setTimeout(300_000);
+
+    // Create agent and issue
+    const agent = await createAgent(token, wsId, `E2E-Cancel-${Date.now()}`, embeddedRuntime.id);
+    createdAgentIds.push(agent.id);
+
+    const issue = await api.createIssue(`E2E Cancel Test ${Date.now()}`, {
+      description:
+        "Search the web for the history of artificial intelligence. Write a detailed 500-word summary covering all major milestones from the 1950s to today.",
+    });
+
+    // Assign agent to trigger a task
+    await assignIssueToAgent(token, wsId, issue.id, agent.id);
+
+    // Poll until task is running (sandbox creation can take 30-60s)
+    await pollUntil(
+      () => listTasksByIssue(token, wsId, issue.id),
+      (t) => t.some((task) => task.status === "running" || task.status === "dispatched"),
+      180_000,
+      3_000,
+    );
+
+    // Login and navigate to the issue page
+    await loginAsDefault(page);
+    await page.evaluate((w) => {
+      localStorage.setItem("multica_workspace_id", w);
+    }, wsId);
+    await page.goto(`/issues/${issue.id}`);
+
+    // Wait for the agent live card to appear (shows "is working" text)
+    const liveCard = page.locator("text=is working");
+    await expect(liveCard).toBeVisible({ timeout: 60_000 });
+
+    // Take a screenshot of the live card before cancelling
+    await page.screenshot({ path: "e2e/artifacts/cancel-task-before-stop.png" });
+
+    // Click the Stop button on the live card
+    const stopButton = page.locator("button", { hasText: "Stop" });
+    await expect(stopButton).toBeVisible({ timeout: 10_000 });
+    await stopButton.click();
+
+    // Wait for the live card to disappear (task:cancelled WS event removes it)
+    await expect(liveCard).toBeHidden({ timeout: 30_000 });
+
+    // Take a screenshot after cancellation
+    await page.screenshot({ path: "e2e/artifacts/cancel-task-after-stop.png" });
+
+    // Verify execution history shows the cancelled task
+    // The TaskRunHistory component renders "Execution history" collapsible
+    const executionHistory = page.locator("text=Execution history");
+    await expect(executionHistory).toBeVisible({ timeout: 15_000 });
+
+    // Expand the execution history
+    await executionHistory.click();
+
+    // Verify the cancelled status text appears (TaskRunEntry renders status as capitalize text)
+    const cancelledStatus = page.locator("text=Cancelled");
+    await expect(cancelledStatus).toBeVisible({ timeout: 10_000 });
+
+    // Verify the MinusCircle icon is present (rendered as an SVG alongside "Cancelled")
+    // The MinusCircle icon is the sibling of the cancelled task entry
+    // We check that the cancelled entry row contains the muted-foreground styling
+    // (completed = text-success, cancelled = text-muted-foreground, failed = text-destructive)
+    const cancelledEntry = page.locator("button", { hasText: "Cancelled" });
+    await expect(cancelledEntry).toBeVisible();
+
+    // Take final screenshot showing execution history with Cancelled status
+    await page.screenshot({ path: "e2e/artifacts/cancel-task-execution-history.png" });
+
+    // Also verify via API that the task status is "cancelled"
+    const tasks = await listTasksByIssue(token, wsId, issue.id);
+    const cancelledTask = tasks.find((t) => t.status === "cancelled");
+    expect(cancelledTask).toBeDefined();
+  });
+
+  // -- 2. Cancel on already-completed task is a no-op -------------------------
+
+  test("cancel on already-completed task is a no-op (no error)", async () => {
+    test.setTimeout(300_000);
+
+    // Create agent and issue with a trivial prompt so it completes fast
+    const agent = await createAgent(token, wsId, `E2E-CancelNoop-${Date.now()}`, embeddedRuntime.id);
+    createdAgentIds.push(agent.id);
+
+    const issue = await api.createIssue(`E2E Cancel Noop Test ${Date.now()}`, {
+      description: "What is 2+2? Reply with just the number.",
+    });
+
+    // Assign agent to trigger a task
+    await assignIssueToAgent(token, wsId, issue.id, agent.id);
+
+    // Wait for the task to complete
+    const tasks = await pollUntil(
+      () => listTasksByIssue(token, wsId, issue.id),
+      (t) => t.some((task) => task.status === "completed" || task.status === "failed"),
+      240_000,
+      5_000,
+    );
+
+    const completedTask = tasks.find((t) => t.status === "completed" || t.status === "failed");
+    expect(completedTask).toBeDefined();
+
+    // Try to cancel the already-completed task via API
+    // This should not error — it should be a no-op or return a non-5xx response
+    const cancelRes = await cancelTaskViaApi(token, wsId, issue.id, completedTask!.id);
+
+    // Accept 200 (OK/no-op) or 4xx (already completed — client error, not server error)
+    // The key assertion: no 5xx server error
+    expect(cancelRes.status).toBeLessThan(500);
+
+    // Verify the task status is still completed/failed (not changed to cancelled)
+    const tasksAfter = await listTasksByIssue(token, wsId, issue.id);
+    const sameTask = tasksAfter.find((t) => t.id === completedTask!.id);
+    expect(sameTask).toBeDefined();
+    expect(sameTask!.status).toBe(completedTask!.status);
+  });
+});

--- a/e2e/cancel-task.spec.ts
+++ b/e2e/cancel-task.spec.ts
@@ -249,20 +249,23 @@ test.describe("Cancel Task (I3)", () => {
     const cancelledStatus = page.locator("text=Cancelled");
     await expect(cancelledStatus).toBeVisible({ timeout: 10_000 });
 
-    // Verify the MinusCircle icon is present (rendered as an SVG alongside "Cancelled")
-    // The MinusCircle icon is the sibling of the cancelled task entry
-    // We check that the cancelled entry row contains the muted-foreground styling
-    // (completed = text-success, cancelled = text-muted-foreground, failed = text-destructive)
+    // Verify the cancelled entry uses muted styling (not red/destructive)
     const cancelledEntry = page.locator("button", { hasText: "Cancelled" });
     await expect(cancelledEntry).toBeVisible();
+    const cancelledIcon = cancelledEntry.locator("svg").first();
+    await expect(cancelledIcon).toHaveClass(/text-muted-foreground/);
 
     // Take final screenshot showing execution history with Cancelled status
     await page.screenshot({ path: "e2e/artifacts/cancel-task-execution-history.png" });
 
-    // Also verify via API that the task status is "cancelled"
-    const tasks = await listTasksByIssue(token, wsId, issue.id);
-    const cancelledTask = tasks.find((t) => t.status === "cancelled");
-    expect(cancelledTask).toBeDefined();
+    // Verify via API that the task status is "cancelled" (poll to avoid race with WS)
+    const cancelledTasks = await pollUntil(
+      () => listTasksByIssue(token, wsId, issue.id),
+      (t) => t.some((task) => task.status === "cancelled"),
+      15_000,
+      2_000,
+    );
+    expect(cancelledTasks.find((t) => t.status === "cancelled")).toBeDefined();
   });
 
   // -- 2. Cancel on already-completed task is a no-op -------------------------
@@ -296,9 +299,8 @@ test.describe("Cancel Task (I3)", () => {
     // This should not error — it should be a no-op or return a non-5xx response
     const cancelRes = await cancelTaskViaApi(token, wsId, issue.id, completedTask!.id);
 
-    // Accept 200 (OK/no-op) or 4xx (already completed — client error, not server error)
-    // The key assertion: no 5xx server error
-    expect(cancelRes.status).toBeLessThan(500);
+    // Cancel on a completed task is a no-op — backend returns 200
+    expect(cancelRes.ok).toBeTruthy();
 
     // Verify the task status is still completed/failed (not changed to cancelled)
     const tasksAfter = await listTasksByIssue(token, wsId, issue.id);

--- a/packages/views/agents/config.ts
+++ b/packages/views/agents/config.ts
@@ -3,6 +3,7 @@ import {
   Clock,
   CheckCircle2,
   XCircle,
+  MinusCircle,
   Loader2,
   Play,
 } from "lucide-react";
@@ -21,5 +22,5 @@ export const taskStatusConfig: Record<string, { label: string; icon: typeof Chec
   running: { label: "Running", icon: Loader2, color: "text-success" },
   completed: { label: "Completed", icon: CheckCircle2, color: "text-success" },
   failed: { label: "Failed", icon: XCircle, color: "text-destructive" },
-  cancelled: { label: "Cancelled", icon: XCircle, color: "text-muted-foreground" },
+  cancelled: { label: "Cancelled", icon: MinusCircle, color: "text-muted-foreground" },
 };

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -151,11 +151,18 @@ export function ChatWindow() {
       finalizePending(false);
     });
 
+    const unsubCancelled = subscribe("task:cancelled", (payload) => {
+      const p = payload as { task_id: string };
+      if (!matchesPending(p.task_id)) return;
+      finalizePending(true);
+    });
+
     return () => {
       unsubMessage();
       unsubDone();
       unsubCompleted();
       unsubFailed();
+      unsubCancelled();
     };
   }, [subscribe, addTimelineItem, clearTimeline, setPendingTask, qc]);
 

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Bot, ChevronRight, ChevronDown, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, Square, Maximize2 } from "lucide-react";
+import { Bot, ChevronRight, ChevronDown, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, MinusCircle, Square, Maximize2 } from "lucide-react";
 import { api } from "@multica/core/api";
 import { useWSEvent } from "@multica/core/realtime";
 import type { TaskMessagePayload, TaskCompletedPayload, TaskFailedPayload, TaskCancelledPayload } from "@multica/core/types/events";
@@ -312,9 +312,15 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
   const handleCancel = useCallback(async () => {
     if (cancelling) return;
     setCancelling(true);
+    const timeoutId = setTimeout(() => {
+      setCancelling(false);
+      toast.error("Cancel timed out — try again");
+    }, 10_000);
     try {
       await api.cancelTask(issueId, task.id);
+      clearTimeout(timeoutId);
     } catch (e) {
+      clearTimeout(timeoutId);
       toast.error(e instanceof Error ? e.message : "Failed to cancel task");
       setCancelling(false);
     }
@@ -525,6 +531,8 @@ function TaskRunEntry({ task }: { task: AgentTask }) {
         <ChevronRight className={cn("h-3 w-3 shrink-0 text-muted-foreground transition-transform", open && "rotate-90")} />
         {task.status === "completed" ? (
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-success" />
+        ) : task.status === "cancelled" ? (
+          <MinusCircle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         ) : (
           <XCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
         )}
@@ -532,7 +540,7 @@ function TaskRunEntry({ task }: { task: AgentTask }) {
           {new Date(task.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
         </span>
         {duration && <span className="text-muted-foreground">{duration}</span>}
-        <span className={cn("ml-auto capitalize", task.status === "completed" ? "text-success" : "text-destructive")}>
+        <span className={cn("ml-auto capitalize", task.status === "completed" ? "text-success" : task.status === "cancelled" ? "text-muted-foreground" : "text-destructive")}>
           {task.status}
         </span>
         <span

--- a/server/internal/cloud/sandbox.go
+++ b/server/internal/cloud/sandbox.go
@@ -571,8 +571,10 @@ func drainPTYData(ctx context.Context, dataCh <-chan []byte, msgCh chan<- agent.
 		select {
 		case <-ctx.Done():
 			// Context cancelled (user cancel or timeout). Drain any remaining
-			// buffered data from the channel before returning — sandbox.Stop()
-			// closes DataChan, so these reads are bounded.
+			// buffered data from the channel — sandbox.Stop() closes DataChan
+			// asynchronously, so we wait briefly for late-arriving chunks rather
+			// than returning immediately on an empty channel.
+			drainTimeout := time.After(2 * time.Second)
 			for {
 				select {
 				case data, ok := <-dataCh:
@@ -581,7 +583,7 @@ func drainPTYData(ctx context.Context, dataCh <-chan []byte, msgCh chan<- agent.
 						return
 					}
 					processChunk(data, &lineBuf)
-				default:
+				case <-drainTimeout:
 					flushLineBuf(&lineBuf)
 					return
 				}

--- a/server/internal/cloud/sandbox.go
+++ b/server/internal/cloud/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
@@ -414,11 +415,15 @@ func (sm *SandboxManager) execute(ctx context.Context, taskCfg TaskExecConfig) (
 		return nil, fmt.Errorf("write to pty: %w", err)
 	}
 
-	// Stop sandbox immediately on context cancellation (user cancel or timeout).
-	// This halts the OH process, closes the PTY DataChan, and stops LLM token burn.
-	// sandbox.Stop() is idempotent; safe if the sandbox already finished or is being deleted.
+	// Stop sandbox on external cancellation (user cancel or timeout), but NOT on
+	// normal completion. The drain goroutine sets normalExit before cleanup so we
+	// skip the redundant Stop on already-deleted sandboxes.
+	var normalExit atomic.Bool
 	go func() {
 		<-runCtx.Done()
+		if normalExit.Load() {
+			return
+		}
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer stopCancel()
 		if err := sandbox.Stop(stopCtx); err != nil {
@@ -466,6 +471,9 @@ func (sm *SandboxManager) execute(ctx context.Context, taskCfg TaskExecConfig) (
 		sm.logger.Info("sandbox task finished", "task", taskCfg.TaskID, "status", finalStatus,
 			"duration", duration.Round(time.Millisecond),
 			"textLen", textOutput.Len(), "toolOutputLen", toolOutput.Len())
+
+		// Signal normal completion so the Stop goroutine doesn't fire on cleanup.
+		normalExit.Store(true)
 
 		// Extract artifacts from /workspace/output/ before destroying the sandbox.
 		var artifacts []agent.Artifact
@@ -530,6 +538,34 @@ func drainPTYData(ctx context.Context, dataCh <-chan []byte, msgCh chan<- agent.
 		trySendCloud(msgCh, msg)
 	}
 
+	// processChunk parses complete lines from the buffer and dispatches messages.
+	processChunk := func(data []byte, lineBuf *strings.Builder) {
+		lineBuf.Write(data)
+		for {
+			full := lineBuf.String()
+			idx := strings.Index(full, "\n")
+			if idx < 0 {
+				break
+			}
+			line := full[:idx]
+			lineBuf.Reset()
+			lineBuf.WriteString(full[idx+1:])
+			if msg, ok := ParseOHLine(line); ok {
+				processMsg(msg)
+			} else if trimmed := strings.TrimSpace(line); trimmed != "" && !strings.HasPrefix(trimmed, "$") && !strings.HasPrefix(trimmed, "daytona@") {
+				slog.Warn("sandbox non-json output", "line", trimmed)
+			}
+		}
+	}
+
+	flushLineBuf := func(lineBuf *strings.Builder) {
+		if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
+			if msg, ok := ParseOHLine(remaining); ok {
+				processMsg(msg)
+			}
+		}
+	}
+
 	var lineBuf strings.Builder
 	for {
 		select {
@@ -541,63 +577,21 @@ func drainPTYData(ctx context.Context, dataCh <-chan []byte, msgCh chan<- agent.
 				select {
 				case data, ok := <-dataCh:
 					if !ok {
-						if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
-							if msg, ok := ParseOHLine(remaining); ok {
-								processMsg(msg)
-							}
-						}
+						flushLineBuf(&lineBuf)
 						return
 					}
-					lineBuf.Write(data)
-					for {
-						full := lineBuf.String()
-						idx := strings.Index(full, "\n")
-						if idx < 0 {
-							break
-						}
-						line := full[:idx]
-						lineBuf.Reset()
-						lineBuf.WriteString(full[idx+1:])
-						if msg, ok := ParseOHLine(line); ok {
-							processMsg(msg)
-						}
-					}
+					processChunk(data, &lineBuf)
 				default:
-					// No more buffered data — flush lineBuf and return.
-					if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
-						if msg, ok := ParseOHLine(remaining); ok {
-							processMsg(msg)
-						}
-					}
+					flushLineBuf(&lineBuf)
 					return
 				}
 			}
 		case data, ok := <-dataCh:
 			if !ok {
-				if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
-					if msg, ok := ParseOHLine(remaining); ok {
-						processMsg(msg)
-					}
-				}
+				flushLineBuf(&lineBuf)
 				return
 			}
-			lineBuf.Write(data)
-			for {
-				full := lineBuf.String()
-				idx := strings.Index(full, "\n")
-				if idx < 0 {
-					break
-				}
-				line := full[:idx]
-				lineBuf.Reset()
-				lineBuf.WriteString(full[idx+1:])
-				if msg, ok := ParseOHLine(line); ok {
-					processMsg(msg)
-				} else if trimmed := strings.TrimSpace(line); trimmed != "" && !strings.HasPrefix(trimmed, "$") && !strings.HasPrefix(trimmed, "daytona@") {
-					// Log non-JSON lines (Python tracebacks, errors, etc.)
-					slog.Warn("sandbox non-json output", "line", trimmed)
-				}
-			}
+			processChunk(data, &lineBuf)
 		}
 	}
 }

--- a/server/internal/cloud/sandbox.go
+++ b/server/internal/cloud/sandbox.go
@@ -414,6 +414,20 @@ func (sm *SandboxManager) execute(ctx context.Context, taskCfg TaskExecConfig) (
 		return nil, fmt.Errorf("write to pty: %w", err)
 	}
 
+	// Stop sandbox immediately on context cancellation (user cancel or timeout).
+	// This halts the OH process, closes the PTY DataChan, and stops LLM token burn.
+	// sandbox.Stop() is idempotent; safe if the sandbox already finished or is being deleted.
+	go func() {
+		<-runCtx.Done()
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		if err := sandbox.Stop(stopCtx); err != nil {
+			sm.logger.Warn("sandbox stop on cancel failed", "task", taskCfg.TaskID, "error", err)
+		} else {
+			sm.logger.Info("sandbox stopped on cancellation", "task", taskCfg.TaskID)
+		}
+	}()
+
 	// Result channel (msgCh already created above for lifecycle messages).
 	resCh := make(chan agent.Result, 1)
 
@@ -520,7 +534,44 @@ func drainPTYData(ctx context.Context, dataCh <-chan []byte, msgCh chan<- agent.
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			// Context cancelled (user cancel or timeout). Drain any remaining
+			// buffered data from the channel before returning — sandbox.Stop()
+			// closes DataChan, so these reads are bounded.
+			for {
+				select {
+				case data, ok := <-dataCh:
+					if !ok {
+						if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
+							if msg, ok := ParseOHLine(remaining); ok {
+								processMsg(msg)
+							}
+						}
+						return
+					}
+					lineBuf.Write(data)
+					for {
+						full := lineBuf.String()
+						idx := strings.Index(full, "\n")
+						if idx < 0 {
+							break
+						}
+						line := full[:idx]
+						lineBuf.Reset()
+						lineBuf.WriteString(full[idx+1:])
+						if msg, ok := ParseOHLine(line); ok {
+							processMsg(msg)
+						}
+					}
+				default:
+					// No more buffered data — flush lineBuf and return.
+					if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {
+						if msg, ok := ParseOHLine(remaining); ok {
+							processMsg(msg)
+						}
+					}
+					return
+				}
+			}
 		case data, ok := <-dataCh:
 			if !ok {
 				if remaining := strings.TrimSpace(lineBuf.String()); remaining != "" {

--- a/server/internal/cloud/sandbox_cancel_test.go
+++ b/server/internal/cloud/sandbox_cancel_test.go
@@ -202,15 +202,19 @@ func TestSandboxStop_ConcurrentDrain(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	// Wait for first output (OH has started)
+	// Single-owner goroutine reads DataChan and tees into a local channel.
+	// This avoids two goroutines racing on the same channel.
+	teeCh := make(chan []byte, 256)
 	firstOutput := make(chan struct{})
 	go func() {
-		for range handle.DataChan() {
-			select {
-			case <-firstOutput:
-			default:
+		defer close(teeCh)
+		first := true
+		for data := range handle.DataChan() {
+			if first {
 				close(firstOutput)
+				first = false
 			}
+			teeCh <- data
 		}
 	}()
 
@@ -228,11 +232,11 @@ func TestSandboxStop_ConcurrentDrain(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	// Goroutine 1: drain PTY data (simulates the drain goroutine)
+	// Goroutine 1: drain PTY data via tee channel (simulates the drain goroutine)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		drainPTYData(runCtx, handle.DataChan(), msgCh, &textOutput, &toolOutput)
+		drainPTYData(runCtx, teeCh, msgCh, &textOutput, &toolOutput)
 		close(msgCh)
 	}()
 

--- a/server/internal/cloud/sandbox_cancel_test.go
+++ b/server/internal/cloud/sandbox_cancel_test.go
@@ -1,0 +1,273 @@
+//go:build integration
+
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// createTestSandbox creates a minimal sandbox for cancel tests.
+// Returns the sandbox and a cleanup function.
+func createTestSandbox(t *testing.T, ctx context.Context) *daytona.Sandbox {
+	t.Helper()
+	apiKey := os.Getenv("DAYTONA_API_KEY")
+	if apiKey == "" {
+		t.Skip("DAYTONA_API_KEY not set")
+	}
+
+	client, err := daytona.NewClientWithConfig(&types.DaytonaConfig{APIKey: apiKey})
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+	t.Cleanup(func() { client.Close(context.Background()) })
+
+	image := daytona.DebianSlim(nil).
+		PipInstall([]string{"openharness-ai==0.1.6"}).
+		Env("TERM", "dumb")
+
+	t.Log("Creating sandbox...")
+	sandbox, err := client.Create(ctx, types.ImageParams{
+		SandboxBaseParams: types.SandboxBaseParams{
+			EnvVars: map[string]string{"TERM": "dumb"},
+		},
+		Image: image,
+	}, options.WithTimeout(5*time.Minute))
+	if err != nil {
+		t.Fatalf("Create sandbox: %v", err)
+	}
+	t.Logf("Sandbox created: %s", sandbox.ID)
+
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 60*time.Second)
+		defer c()
+		if err := sandbox.Delete(cleanupCtx); err != nil {
+			t.Logf("WARNING: delete sandbox %s: %v", sandbox.ID, err)
+		}
+	})
+
+	return sandbox
+}
+
+// TV1: sandbox.Stop() halts a running process and closes PTY DataChan.
+func TestSandboxStop_HaltsProcess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sandbox := createTestSandbox(t, ctx)
+
+	// Start a long-running process via PTY
+	sessionID := fmt.Sprintf("tv1-%d", time.Now().UnixMilli())
+	handle, err := sandbox.Process.CreatePty(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("CreatePty: %v", err)
+	}
+	if err := handle.WaitForConnection(ctx); err != nil {
+		t.Fatalf("WaitForConnection: %v", err)
+	}
+
+	// Run a process that will run for a long time
+	_, err = handle.Write([]byte("sleep 300\n"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	time.Sleep(1 * time.Second) // let it start
+
+	// Track when DataChan closes
+	dataChanClosed := make(chan struct{})
+	go func() {
+		for range handle.DataChan() {
+		}
+		close(dataChanClosed)
+	}()
+
+	// Stop the sandbox
+	t.Log("Calling sandbox.Stop()...")
+	stopStart := time.Now()
+	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer stopCancel()
+	if err := sandbox.Stop(stopCtx); err != nil {
+		t.Fatalf("sandbox.Stop: %v", err)
+	}
+	stopDuration := time.Since(stopStart)
+	t.Logf("sandbox.Stop() completed in %v", stopDuration)
+
+	// DataChan should close within 5 seconds of Stop
+	select {
+	case <-dataChanClosed:
+		t.Log("DataChan closed after Stop — good")
+	case <-time.After(5 * time.Second):
+		t.Fatal("DataChan did not close within 5s of sandbox.Stop()")
+	}
+
+	handle.Disconnect()
+
+	// Verify the sleep process is gone (sandbox is stopped, Start to check)
+	startCtx, startCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer startCancel()
+	if err := sandbox.Start(startCtx); err != nil {
+		t.Fatalf("sandbox.Start after stop: %v", err)
+	}
+
+	result, err := sandbox.Process.ExecuteCommand(ctx, "pgrep -f 'sleep 300' || echo 'no-process'")
+	if err != nil {
+		t.Fatalf("pgrep: %v", err)
+	}
+	if !strings.Contains(result.Result, "no-process") {
+		t.Errorf("sleep process still running after Stop+Start: %s", result.Result)
+	}
+	t.Logf("Process check after restart: %s", strings.TrimSpace(result.Result))
+}
+
+// TV2: Stop() then Delete() in sequence is safe.
+func TestSandboxStop_ThenDelete(t *testing.T) {
+	apiKey := os.Getenv("DAYTONA_API_KEY")
+	if apiKey == "" {
+		t.Skip("DAYTONA_API_KEY not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	client, err := daytona.NewClientWithConfig(&types.DaytonaConfig{APIKey: apiKey})
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+	defer client.Close(ctx)
+
+	image := daytona.DebianSlim(nil).Env("TERM", "dumb")
+	sandbox, err := client.Create(ctx, types.ImageParams{
+		SandboxBaseParams: types.SandboxBaseParams{
+			EnvVars: map[string]string{"TERM": "dumb"},
+		},
+		Image: image,
+	}, options.WithTimeout(5*time.Minute))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Logf("Sandbox created: %s", sandbox.ID)
+
+	// Stop then Delete — both should succeed
+	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer stopCancel()
+	if err := sandbox.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	t.Log("Stop succeeded")
+
+	deleteCtx, deleteCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer deleteCancel()
+	if err := sandbox.Delete(deleteCtx); err != nil {
+		t.Fatalf("Delete after Stop: %v", err)
+	}
+	t.Log("Delete after Stop succeeded")
+}
+
+// TV6: Concurrent sandbox.Stop() + drainPTYData is race-free.
+// Run with: go test -race -tags integration -run TestSandboxStop_ConcurrentDrain
+func TestSandboxStop_ConcurrentDrain(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sandbox := createTestSandbox(t, ctx)
+
+	googleKey := os.Getenv("GOOGLE_AI_API_KEY")
+	if googleKey == "" {
+		t.Skip("GOOGLE_AI_API_KEY required for OH execution")
+	}
+
+	// Start OH with a multi-turn prompt that takes a while
+	sessionID := fmt.Sprintf("tv6-%d", time.Now().UnixMilli())
+	handle, err := sandbox.Process.CreatePty(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("CreatePty: %v", err)
+	}
+	if err := handle.WaitForConnection(ctx); err != nil {
+		t.Fatalf("WaitForConnection: %v", err)
+	}
+
+	cmd := fmt.Sprintf(`oh -p "Search for 10 different topics and write a long report" --output-format stream-json --api-format openai --base-url "%s" --api-key "%s" --model "%s" --max-turns 5 --permission-mode full_auto --bare 2>/dev/null`,
+		fallbackBaseURL, googleKey, fallbackModel)
+	if _, err := handle.Write([]byte(cmd + "\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Wait for first output (OH has started)
+	firstOutput := make(chan struct{})
+	go func() {
+		for range handle.DataChan() {
+			select {
+			case <-firstOutput:
+			default:
+				close(firstOutput)
+			}
+		}
+	}()
+
+	select {
+	case <-firstOutput:
+		t.Log("First OH output received")
+	case <-time.After(60 * time.Second):
+		t.Fatal("No OH output after 60s")
+	}
+
+	// Now simulate the cancel flow: Stop + drain concurrently
+	runCtx, runCancel := context.WithCancel(ctx)
+	msgCh := make(chan agent.Message, 256)
+	var textOutput, toolOutput strings.Builder
+
+	var wg sync.WaitGroup
+
+	// Goroutine 1: drain PTY data (simulates the drain goroutine)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		drainPTYData(runCtx, handle.DataChan(), msgCh, &textOutput, &toolOutput)
+		close(msgCh)
+	}()
+
+	// Goroutine 2: Stop sandbox (simulates the stop goroutine)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runCancel() // cancel context first
+		stopCtx, sc := context.WithTimeout(context.Background(), 5*time.Second)
+		defer sc()
+		if err := sandbox.Stop(stopCtx); err != nil {
+			t.Logf("Stop during drain: %v (may be expected)", err)
+		}
+	}()
+
+	// Both goroutines must complete without panic or deadlock
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Log("Concurrent stop+drain completed cleanly")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Concurrent stop+drain hung for 30s")
+	}
+
+	// Count recovered messages
+	var msgs []agent.Message
+	for m := range msgCh {
+		msgs = append(msgs, m)
+	}
+	t.Logf("Recovered %d messages during concurrent cancel", len(msgs))
+
+	handle.Disconnect()
+}

--- a/server/internal/cloud/sandbox_test.go
+++ b/server/internal/cloud/sandbox_test.go
@@ -198,6 +198,53 @@ func TestLineBuffer_ToolOutputFallback(t *testing.T) {
 	}
 }
 
+// TV3: Verify drainPTYData recovers buffered messages after context cancellation.
+// When sandbox.Stop() closes DataChan and the context is cancelled, we must
+// still drain remaining buffered data before returning.
+func TestLineBuffer_DrainAfterCancel(t *testing.T) {
+	msgCh := make(chan agent.Message, 256)
+	dataCh := make(chan []byte, 10)
+
+	// Buffer 3 complete messages before cancel
+	dataCh <- []byte("{\"type\": \"assistant_delta\", \"text\": \"One\"}\n")
+	dataCh <- []byte("{\"type\": \"assistant_delta\", \"text\": \"Two\"}\n")
+	dataCh <- []byte("{\"type\": \"assistant_delta\", \"text\": \"Three\"}\n")
+	close(dataCh) // simulate sandbox.Stop() closing the PTY DataChan
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel context — simulates daemon cancel-poll
+
+	var textOutput, toolOutput strings.Builder
+	done := make(chan struct{})
+	go func() {
+		drainPTYData(ctx, dataCh, msgCh, &textOutput, &toolOutput)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainPTYData hung after context cancellation")
+	}
+	close(msgCh)
+
+	var msgs []agent.Message
+	for m := range msgCh {
+		msgs = append(msgs, m)
+	}
+
+	// All 3 buffered messages must be recovered even with cancelled context
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages from buffer drain, got %d", len(msgs))
+	}
+	if msgs[0].Content != "One" || msgs[1].Content != "Two" || msgs[2].Content != "Three" {
+		t.Errorf("unexpected messages: %+v", msgs)
+	}
+	if textOutput.String() != "OneTwoThree" {
+		t.Errorf("expected text output 'OneTwoThree', got %q", textOutput.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // detectContentType tests
 // ---------------------------------------------------------------------------

--- a/server/internal/cloud/sandbox_test.go
+++ b/server/internal/cloud/sandbox_test.go
@@ -141,11 +141,12 @@ func TestLineBuffer_ContextCancellation(t *testing.T) {
 		close(done)
 	}()
 
-	// Must complete within 2 seconds (proves no infinite hang)
+	// Must complete within 5 seconds (the post-cancel drain waits up to 2s
+	// for late-arriving data before returning, so we allow headroom).
 	select {
 	case <-done:
 		// good
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("drainPTYData hung after context cancellation")
 	}
 	close(msgCh)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -867,10 +867,10 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 
-	// Poll for cancellation every 5 seconds while the task is running.
+	// Poll for cancellation every 2 seconds while the task is running.
 	cancelledByPoll := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -148,6 +148,18 @@ func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UU
 func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	task, err := s.Queries.CancelAgentTask(ctx, taskID)
 	if err != nil {
+		// Task is already in a terminal state (completed, failed, or already cancelled).
+		// Return it as-is — cancelling a finished task is a no-op per acceptance criteria.
+		// Still broadcast task:cancelled so the frontend clears any stale live card.
+		if errors.Is(err, pgx.ErrNoRows) {
+			existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID)
+			if lookupErr != nil {
+				return nil, fmt.Errorf("cancel task: task not found")
+			}
+			slog.Info("cancel task: already in terminal state", "task_id", util.UUIDToString(taskID), "status", existing.Status)
+			s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, existing)
+			return &existing, nil
+		}
 		return nil, fmt.Errorf("cancel task: %w", err)
 	}
 
@@ -156,7 +168,7 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 
-	// Broadcast cancellation as a task:failed event so frontends clear the live card
+	// Broadcast cancellation so frontends clear the live card
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 
 	return &task, nil

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -150,7 +150,9 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 	if err != nil {
 		// Task is already in a terminal state (completed, failed, or already cancelled).
 		// Return it as-is — cancelling a finished task is a no-op per acceptance criteria.
-		// Still broadcast task:cancelled so the frontend clears any stale live card.
+		// We intentionally broadcast task:cancelled even for completed/failed tasks so
+		// the frontend clears any stale live card (e.g., daemon cancel-poll beat the
+		// user's API call, leaving the card orphaned without a WS event).
 		if errors.Is(err, pgx.ErrNoRows) {
 			existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID)
 			if lookupErr != nil {


### PR DESCRIPTION
## Summary
- Backend: sandbox.Stop() on cancel, PTY buffer drain, 2s poll, no-op broadcast fix
- Frontend: gray MinusCircle for cancelled, chat WS subscription, 10s cancel timeout
- Integration test scaffolding for sandbox stop/delete/race safety

Closes #17

## Test plan
- [x] Cancel running task — card disappears within 2-3s
- [x] Cancelled task shows gray ⊖ icon in execution history (not red ✕)
- [x] Cancel already-completed task is a no-op (200, no error)
- [x] Chat recovers when task cancelled from issue view
- [ ] Cancel button re-enables after 10s if backend hangs

## Fast-follow issues filed
- #41 — Cancel attribution (who cancelled)
- #45 — Broadcast gaps (bulk cancel, StartTask, enqueue)
- #46 — Retry button after cancel/fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distinct icon/style for cancelled tasks across UI.
  * Chat UI finalizes pending tasks on cancel and refreshes messages.
  * More responsive cancellation polling (now every 2s).

* **Bug Fixes**
  * Cancel action times out after 10s with user-facing error.
  * Cancelling already-terminal tasks is a no-op but emits cancelled state.
  * PTY drain preserves buffered output on cancellation to prevent data loss.

* **Tests**
  * Added sandbox cancellation, PTY-drain, and end-to-end cancel-task tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->