### PR TITLE
feat(agent): retry button for failed/cancelled tasks

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -472,6 +472,12 @@ export class ApiClient {
     });
   }
 
+  async retryTask(taskId: string): Promise<AgentTask> {
+    return this.fetch(`/api/tasks/${taskId}/retry`, {
+      method: "POST",
+    });
+  }
+
   // Inbox
   async listInbox(): Promise<InboxItem[]> {
     return this.fetch("/api/inbox");

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -34,6 +34,7 @@ export interface AgentTask {
   completed_at: string | null;
   result: unknown;
   error: string | null;
+  retried_from_id: string | null;
   created_at: string;
 }
 

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -121,6 +121,20 @@ describe("TaskRunEntry retry button", () => {
     expect(screen.queryByText("Retry")).not.toBeInTheDocument();
   });
 
+  it("hides retry button when active task exists on issue", async () => {
+    const failedTask = makeTask({ id: "task-1", status: "failed" });
+    const runningTask = makeTask({ id: "task-2", status: "running", error: null });
+    mockListTasksByIssue.mockResolvedValue([runningTask, failedTask]);
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    // Failed task is visible but Retry button is hidden (active task running)
+    await waitFor(() => expect(screen.getByText("failed")).toBeInTheDocument());
+    expect(screen.queryByText("Retry")).not.toBeInTheDocument();
+  });
+
   it("hides retry button when task was already retried", async () => {
     const originalTask = makeTask({ id: "task-1", status: "failed" });
     const retryTask = makeTask({ id: "task-2", status: "completed", error: null, retried_from_id: "task-1" });
@@ -172,7 +186,25 @@ describe("TaskRunEntry retry button", () => {
     await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
   });
 
-  it("shows toast on retry failure", async () => {
+  it("shows user-friendly toast for closed issue", async () => {
+    const { toast } = await import("sonner");
+    const failedTask = makeTask({ status: "failed" });
+    mockListTasksByIssue.mockResolvedValue([failedTask]);
+    mockRetryTask.mockRejectedValue(new Error("cannot retry: issue is closed"));
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Retry"));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(
+      "This issue is closed — reopen it to retry"
+    ));
+  });
+
+  it("shows user-friendly toast for active task conflict", async () => {
     const { toast } = await import("sonner");
     const failedTask = makeTask({ status: "failed" });
     mockListTasksByIssue.mockResolvedValue([failedTask]);
@@ -185,6 +217,8 @@ describe("TaskRunEntry retry button", () => {
     await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Retry"));
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("an active task already exists for this issue"));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(
+      "A task is already running — wait for it to finish"
+    ));
   });
 });

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -121,7 +121,7 @@ describe("TaskRunEntry retry button", () => {
     expect(screen.queryByText("Retry")).not.toBeInTheDocument();
   });
 
-  it("shows 'retried' label when task was already retried", async () => {
+  it("hides retry button when task was already retried", async () => {
     const originalTask = makeTask({ id: "task-1", status: "failed" });
     const retryTask = makeTask({ id: "task-2", status: "completed", error: null, retried_from_id: "task-1" });
     mockListTasksByIssue.mockResolvedValue([retryTask, originalTask]);
@@ -130,12 +130,12 @@ describe("TaskRunEntry retry button", () => {
     await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
     fireEvent.click(screen.getByText(/Execution history/));
 
-    await waitFor(() => expect(screen.getByText("retried")).toBeInTheDocument());
-    // The original task should not have a Retry button
+    // The original task should not have a Retry button (already retried)
+    await waitFor(() => expect(screen.getByText("failed")).toBeInTheDocument());
     expect(screen.queryByText("Retry")).not.toBeInTheDocument();
   });
 
-  it("calls api.retryTask on click and refreshes list", async () => {
+  it("calls api.retryTask on click, hides button, and refreshes list", async () => {
     const failedTask = makeTask({ status: "failed" });
     mockListTasksByIssue.mockResolvedValue([failedTask]);
     mockRetryTask.mockResolvedValue(makeTask({ id: "task-2", status: "queued" }));
@@ -147,9 +147,29 @@ describe("TaskRunEntry retry button", () => {
     await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Retry"));
 
-    await waitFor(() => expect(mockRetryTask).toHaveBeenCalledWith("task-1"));
-    // After success, should refresh task list
+    // Shows "Retrying..." during the request
+    await waitFor(() => expect(screen.getByText("Retrying...")).toBeInTheDocument());
+
+    // After success, button disappears and task list refreshes
+    await waitFor(() => expect(screen.queryByText("Retry")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Retrying...")).not.toBeInTheDocument());
     expect(mockListTasksByIssue).toHaveBeenCalledWith("issue-1");
+  });
+
+  it("reverts to Retry button on failure", async () => {
+    const failedTask = makeTask({ status: "failed" });
+    mockListTasksByIssue.mockResolvedValue([failedTask]);
+    mockRetryTask.mockRejectedValue(new Error("an active task already exists"));
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Retry"));
+
+    // After failure, button reverts back to "Retry"
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
   });
 
   it("shows toast on retry failure", async () => {

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { AgentTask } from "@multica/core/types/agent";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before imports that use them
+// ---------------------------------------------------------------------------
+
+const mockRetryTask = vi.fn();
+const mockListTasksByIssue = vi.fn();
+const mockGetActiveTasksForIssue = vi.fn();
+const mockListTaskMessages = vi.fn();
+const mockCancelTask = vi.fn();
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    retryTask: (...args: any[]) => mockRetryTask(...args),
+    listTasksByIssue: (...args: any[]) => mockListTasksByIssue(...args),
+    getActiveTasksForIssue: (...args: any[]) => mockGetActiveTasksForIssue(...args),
+    listTaskMessages: (...args: any[]) => mockListTaskMessages(...args),
+    cancelTask: (...args: any[]) => mockCancelTask(...args),
+  },
+}));
+
+vi.mock("@multica/core/realtime", () => ({
+  useWSEvent: vi.fn(),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: () => "Test Agent",
+    getMemberName: () => "Test User",
+    getAgentName: () => "Test Agent",
+    getActorInitials: () => "TA",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <div data-testid="actor-avatar" />,
+}));
+
+vi.mock("./agent-transcript-dialog", () => ({
+  AgentTranscriptDialog: () => null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+// Import after mocks
+import { TaskRunHistory } from "./agent-live-card";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "issue-1",
+    status: "failed",
+    priority: 0,
+    dispatched_at: "2026-04-16T02:28:00Z",
+    started_at: "2026-04-16T02:28:01Z",
+    completed_at: "2026-04-16T02:28:13Z",
+    result: null,
+    error: "Sandbox timeout after 150s",
+    retried_from_id: null,
+    created_at: "2026-04-16T02:28:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TaskRunEntry retry button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActiveTasksForIssue.mockResolvedValue({ tasks: [] });
+    mockListTaskMessages.mockResolvedValue([]);
+  });
+
+  it("shows retry button for failed tasks", async () => {
+    const failedTask = makeTask({ status: "failed" });
+    mockListTasksByIssue.mockResolvedValue([failedTask]);
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+
+    // Expand the history
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+  });
+
+  it("shows retry button for cancelled tasks", async () => {
+    const cancelledTask = makeTask({ status: "cancelled" });
+    mockListTasksByIssue.mockResolvedValue([cancelledTask]);
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+  });
+
+  it("does not show retry button for completed tasks", async () => {
+    const completedTask = makeTask({ status: "completed", error: null });
+    mockListTasksByIssue.mockResolvedValue([completedTask]);
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("completed")).toBeInTheDocument());
+    expect(screen.queryByText("Retry")).not.toBeInTheDocument();
+  });
+
+  it("shows 'retried' label when task was already retried", async () => {
+    const originalTask = makeTask({ id: "task-1", status: "failed" });
+    const retryTask = makeTask({ id: "task-2", status: "completed", error: null, retried_from_id: "task-1" });
+    mockListTasksByIssue.mockResolvedValue([retryTask, originalTask]);
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("retried")).toBeInTheDocument());
+    // The original task should not have a Retry button
+    expect(screen.queryByText("Retry")).not.toBeInTheDocument();
+  });
+
+  it("calls api.retryTask on click and refreshes list", async () => {
+    const failedTask = makeTask({ status: "failed" });
+    mockListTasksByIssue.mockResolvedValue([failedTask]);
+    mockRetryTask.mockResolvedValue(makeTask({ id: "task-2", status: "queued" }));
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Retry"));
+
+    await waitFor(() => expect(mockRetryTask).toHaveBeenCalledWith("task-1"));
+    // After success, should refresh task list
+    expect(mockListTasksByIssue).toHaveBeenCalledWith("issue-1");
+  });
+
+  it("shows toast on retry failure", async () => {
+    const { toast } = await import("sonner");
+    const failedTask = makeTask({ status: "failed" });
+    mockListTasksByIssue.mockResolvedValue([failedTask]);
+    mockRetryTask.mockRejectedValue(new Error("an active task already exists for this issue"));
+
+    render(<TaskRunHistory issueId="issue-1" />);
+    await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Execution history/));
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Retry"));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("an active task already exists for this issue"));
+  });
+});

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -190,7 +190,7 @@ describe("TaskRunEntry retry button", () => {
     const { toast } = await import("sonner");
     const failedTask = makeTask({ status: "failed" });
     mockListTasksByIssue.mockResolvedValue([failedTask]);
-    mockRetryTask.mockRejectedValue(new Error("cannot retry: issue is closed"));
+    mockRetryTask.mockRejectedValue(new Error("cannot retry: issue is done"));
 
     render(<TaskRunHistory issueId="issue-1" />);
     await waitFor(() => expect(screen.getByText(/Execution history/)).toBeInTheDocument());
@@ -200,7 +200,7 @@ describe("TaskRunEntry retry button", () => {
     fireEvent.click(screen.getByText("Retry"));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(
-      "This issue is closed — reopen it to retry"
+      "This issue is marked as done — change its status to retry"
     ));
   });
 

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -480,6 +480,17 @@ export function TaskRunHistory({ issueId }: TaskRunHistoryProps) {
     }, [issueId]),
   );
 
+  // Refresh when a new task is dispatched (retry creates a task with
+  // retried_from_id — re-fetching hides the Retry button on the original).
+  useWSEvent(
+    "task:dispatch",
+    useCallback((payload: unknown) => {
+      const p = payload as { issue_id?: string };
+      if (p.issue_id !== issueId) return;
+      api.listTasksByIssue(issueId).then(setTasks).catch(console.error);
+    }, [issueId]),
+  );
+
   const completedTasks = tasks.filter((t) => t.status === "completed" || t.status === "failed" || t.status === "cancelled");
   if (completedTasks.length === 0) return null;
 
@@ -532,7 +543,7 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
   const isRetryable = task.status === "failed" || task.status === "cancelled";
   const alreadyRetried = retried || allTasks.some((t) => t.retried_from_id === task.id);
   const hasActiveTask = allTasks.some((t) => t.status === "queued" || t.status === "dispatched" || t.status === "running");
-  const showRetryButton = isRetryable && !alreadyRetried;
+  const showRetryButton = isRetryable && !alreadyRetried && !hasActiveTask;
 
   const handleRetry = useCallback(async () => {
     if (retrying || alreadyRetried) return;
@@ -542,7 +553,13 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
       setRetried(true);
       onRetried();
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to retry task";
+      const raw = e instanceof Error ? e.message : "Failed to retry task";
+      // Translate backend errors into user-friendly messages.
+      const msg = raw.includes("issue is closed")
+        ? "This issue is closed — reopen it to retry"
+        : raw.includes("active task")
+          ? "A task is already running — wait for it to finish"
+          : raw;
       toast.error(msg);
       setRetrying(false);
     }
@@ -567,10 +584,10 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
           <span
             role="button"
             tabIndex={0}
-            onClick={(e) => { e.stopPropagation(); if (!(retrying || hasActiveTask)) handleRetry(); }}
-            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); if (!(retrying || hasActiveTask)) handleRetry(); } }}
-            className={cn("ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer", (retrying || hasActiveTask) && "opacity-50 pointer-events-none")}
-            title={hasActiveTask ? "A task is already running on this issue" : "Retry this task"}
+            onClick={(e) => { e.stopPropagation(); if (!retrying) handleRetry(); }}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); if (!retrying) handleRetry(); } }}
+            className={cn("ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer", retrying && "opacity-50 pointer-events-none")}
+            title="Retry this task"
           >
             {retrying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
             <span>{retrying ? "Retrying..." : "Retry"}</span>

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -555,8 +555,8 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
     } catch (e) {
       const raw = e instanceof Error ? e.message : "Failed to retry task";
       // Translate backend errors into user-friendly messages.
-      const msg = raw.includes("issue is closed")
-        ? "This issue is closed — reopen it to retry"
+      const msg = raw.includes("issue is done") || raw.includes("issue is closed")
+        ? "This issue is marked as done — change its status to retry"
         : raw.includes("active task")
           ? "A task is already running — wait for it to finish"
           : raw;

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -564,15 +564,17 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
         </span>
         {duration && <span className="text-muted-foreground">{duration}</span>}
         {isRetryable && !alreadyRetried && (
-          <button
-            onClick={(e) => { e.stopPropagation(); handleRetry(); }}
-            disabled={retrying || hasActiveTask}
-            className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-50"
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); if (!(retrying || hasActiveTask)) handleRetry(); }}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); if (!(retrying || hasActiveTask)) handleRetry(); } }}
+            className={cn("ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer", (retrying || hasActiveTask) && "opacity-50 pointer-events-none")}
             title={hasActiveTask ? "A task is already running on this issue" : "Retry this task"}
           >
             {retrying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
             <span>Retry</span>
-          </button>
+          </span>
         )}
         {isRetryable && alreadyRetried && (
           <span className="ml-auto text-muted-foreground">retried</span>

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -532,6 +532,7 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
   const isRetryable = task.status === "failed" || task.status === "cancelled";
   const alreadyRetried = retried || allTasks.some((t) => t.retried_from_id === task.id);
   const hasActiveTask = allTasks.some((t) => t.status === "queued" || t.status === "dispatched" || t.status === "running");
+  const showRetryButton = isRetryable && !alreadyRetried;
 
   const handleRetry = useCallback(async () => {
     if (retrying || alreadyRetried) return;
@@ -543,7 +544,6 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to retry task";
       toast.error(msg);
-    } finally {
       setRetrying(false);
     }
   }, [task.id, retrying, alreadyRetried, onRetried]);
@@ -563,7 +563,7 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
           {new Date(task.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
         </span>
         {duration && <span className="text-muted-foreground">{duration}</span>}
-        {isRetryable && !alreadyRetried && (
+        {showRetryButton && (
           <span
             role="button"
             tabIndex={0}
@@ -573,14 +573,11 @@ function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks
             title={hasActiveTask ? "A task is already running on this issue" : "Retry this task"}
           >
             {retrying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
-            <span>Retry</span>
+            <span>{retrying ? "Retrying..." : "Retry"}</span>
           </span>
         )}
-        {isRetryable && alreadyRetried && (
-          <span className="ml-auto text-muted-foreground">retried</span>
-        )}
         <span className={cn(
-          !isRetryable && "ml-auto",
+          !showRetryButton && "ml-auto",
           "capitalize",
           task.status === "completed" ? "text-success" : task.status === "cancelled" ? "text-muted-foreground" : "text-destructive",
         )}>

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Bot, ChevronRight, ChevronDown, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, MinusCircle, Square, Maximize2 } from "lucide-react";
+import { Bot, ChevronRight, ChevronDown, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, MinusCircle, Square, Maximize2, RotateCcw } from "lucide-react";
 import { api } from "@multica/core/api";
 import { useWSEvent } from "@multica/core/realtime";
 import type { TaskMessagePayload, TaskCompletedPayload, TaskFailedPayload, TaskCancelledPayload } from "@multica/core/types/events";
@@ -493,7 +493,9 @@ export function TaskRunHistory({ issueId }: TaskRunHistoryProps) {
       <CollapsibleContent>
         <div className="mt-1 space-y-2">
           {completedTasks.map((task) => (
-            <TaskRunEntry key={task.id} task={task} />
+            <TaskRunEntry key={task.id} task={task} allTasks={tasks} onRetried={() => {
+              api.listTasksByIssue(issueId).then(setTasks).catch(console.error);
+            }} />
           ))}
         </div>
       </CollapsibleContent>
@@ -501,11 +503,13 @@ export function TaskRunHistory({ issueId }: TaskRunHistoryProps) {
   );
 }
 
-function TaskRunEntry({ task }: { task: AgentTask }) {
+function TaskRunEntry({ task, allTasks, onRetried }: { task: AgentTask; allTasks: AgentTask[]; onRetried: () => void }) {
   const { getActorName } = useActorName();
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<TimelineItem[] | null>(null);
   const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  const [retried, setRetried] = useState(false);
 
   const loadMessages = useCallback(() => {
     if (items !== null) return; // already loaded
@@ -525,6 +529,25 @@ function TaskRunEntry({ task }: { task: AgentTask }) {
     ? formatDuration(task.started_at, task.completed_at)
     : null;
 
+  const isRetryable = task.status === "failed" || task.status === "cancelled";
+  const alreadyRetried = retried || allTasks.some((t) => t.retried_from_id === task.id);
+  const hasActiveTask = allTasks.some((t) => t.status === "queued" || t.status === "dispatched" || t.status === "running");
+
+  const handleRetry = useCallback(async () => {
+    if (retrying || alreadyRetried) return;
+    setRetrying(true);
+    try {
+      await api.retryTask(task.id);
+      setRetried(true);
+      onRetried();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to retry task";
+      toast.error(msg);
+    } finally {
+      setRetrying(false);
+    }
+  }, [task.id, retrying, alreadyRetried, onRetried]);
+
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/30 transition-colors border border-transparent hover:border-border">
@@ -540,7 +563,25 @@ function TaskRunEntry({ task }: { task: AgentTask }) {
           {new Date(task.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
         </span>
         {duration && <span className="text-muted-foreground">{duration}</span>}
-        <span className={cn("ml-auto capitalize", task.status === "completed" ? "text-success" : task.status === "cancelled" ? "text-muted-foreground" : "text-destructive")}>
+        {isRetryable && !alreadyRetried && (
+          <button
+            onClick={(e) => { e.stopPropagation(); handleRetry(); }}
+            disabled={retrying || hasActiveTask}
+            className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-50"
+            title={hasActiveTask ? "A task is already running on this issue" : "Retry this task"}
+          >
+            {retrying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
+            <span>Retry</span>
+          </button>
+        )}
+        {isRetryable && alreadyRetried && (
+          <span className="ml-auto text-muted-foreground">retried</span>
+        )}
+        <span className={cn(
+          !isRetryable && "ml-auto",
+          "capitalize",
+          task.status === "completed" ? "text-success" : task.status === "cancelled" ? "text-muted-foreground" : "text-destructive",
+        )}>
           {task.status}
         </span>
         <span

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -312,6 +312,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 
 			// Tasks (user-facing, with ownership check)
 			r.Post("/api/tasks/{taskId}/cancel", h.CancelTaskByUser)
+			r.Post("/api/tasks/{taskId}/retry", h.RetryTask)
 
 			r.Route("/api/chat/sessions", func(r chi.Router) {
 				r.Post("/", h.CreateChatSession)

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -90,6 +90,7 @@ type AgentTaskResponse struct {
 	CreatedAt      string         `json:"created_at"`
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
+	RetriedFromID         *string        `json:"retried_from_id,omitempty"`         // original task that was retried
 	TriggerCommentID      *string        `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
 	TriggerCommentContent string         `json:"trigger_comment_content,omitempty"` // content of the triggering comment
 	ChatSessionID         string         `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
@@ -123,6 +124,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		Result:       result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
+		RetriedFromID:    uuidToPtr(t.RetriedFromID),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
 	}
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -90,7 +90,7 @@ type AgentTaskResponse struct {
 	CreatedAt      string         `json:"created_at"`
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
-	RetriedFromID         *string        `json:"retried_from_id,omitempty"`         // original task that was retried
+	RetriedFromID         *string        `json:"retried_from_id"`                   // original task that was retried
 	TriggerCommentID      *string        `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
 	TriggerCommentContent string         `json:"trigger_comment_content,omitempty"` // content of the triggering comment
 	ChatSessionID         string         `json:"chat_session_id,omitempty"`         // non-empty for chat tasks

--- a/server/internal/handler/retry.go
+++ b/server/internal/handler/retry.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/multica-ai/multica/server/internal/service"
+)
+
+// RetryTask creates a new queued task as a retry of a failed or cancelled task.
+// POST /api/tasks/{taskId}/retry
+func (h *Handler) RetryTask(w http.ResponseWriter, r *http.Request) {
+	_, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := resolveWorkspaceID(r)
+	taskID := chi.URLParam(r, "taskId")
+
+	task, err := h.TaskService.RetryTask(r.Context(), parseUUID(taskID), workspaceID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrTaskNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, service.ErrTaskNotRetryable),
+			errors.Is(err, service.ErrIssueClosed):
+			writeError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, service.ErrAlreadyRetried),
+			errors.Is(err, service.ErrActiveTaskExists):
+			writeError(w, http.StatusConflict, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "retry failed")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, taskToResponse(*task))
+}

--- a/server/internal/handler/retry_test.go
+++ b/server/internal/handler/retry_test.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRetryTask uses a data-driven approach to validate the retry endpoint
+// across happy-path and all edge cases.
+func TestRetryTask(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// --- fixture setup ---
+	// Get agent + runtime from the shared test fixture.
+	var agentID, runtimeID string
+	err := testPool.QueryRow(ctx,
+		`SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID)
+	if err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	// Helper: create an issue in the test workspace.
+	issueCounter := 9900
+	createIssue := func(t *testing.T, title, status string) string {
+		t.Helper()
+		issueCounter++
+		var id string
+		err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+			VALUES ($1, $2, $3, 'medium', 'member', $4, $5, 0)
+			RETURNING id
+		`, testWorkspaceID, title, status, testUserID, issueCounter).Scan(&id)
+		if err != nil {
+			t.Fatalf("setup: create issue: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, id) })
+		return id
+	}
+
+	// Helper: create a task in a specific status.
+	createTask := func(t *testing.T, issueID, status string) string {
+		t.Helper()
+		var id string
+		err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+			VALUES ($1, $2, $3, $4, 0)
+			RETURNING id
+		`, agentID, runtimeID, issueID, status).Scan(&id)
+		if err != nil {
+			t.Fatalf("setup: create task: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1 OR retried_from_id = $1`, id) })
+		return id
+	}
+
+	// Helper: create a retry task pointing to originalID.
+	createRetryOf := func(t *testing.T, originalID, issueID, status string) string {
+		t.Helper()
+		var id string
+		err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, retried_from_id)
+			VALUES ($1, $2, $3, $4, 0, $5)
+			RETURNING id
+		`, agentID, runtimeID, issueID, status, originalID).Scan(&id)
+		if err != nil {
+			t.Fatalf("setup: create retry task: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, id) })
+		return id
+	}
+
+	// --- data-driven test cases ---
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T) string // returns taskID to retry
+		wantStatus int
+		wantError  string // substring in error response, empty for success
+	}{
+		{
+			name: "retry failed task succeeds",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "retry-failed-test", "todo")
+				return createTask(t, issueID, "failed")
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "retry cancelled task succeeds",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "retry-cancelled-test", "todo")
+				return createTask(t, issueID, "cancelled")
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "retry running task rejected",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "retry-running-test", "todo")
+				return createTask(t, issueID, "running")
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "not retryable",
+		},
+		{
+			name: "retry completed task rejected",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "retry-completed-test", "todo")
+				return createTask(t, issueID, "completed")
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "not retryable",
+		},
+		{
+			name: "retry queued task rejected",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "retry-queued-test", "todo")
+				return createTask(t, issueID, "queued")
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "not retryable",
+		},
+		{
+			name: "double retry rejected",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "double-retry-test", "todo")
+				taskID := createTask(t, issueID, "failed")
+				// Create existing retry task
+				createRetryOf(t, taskID, issueID, "queued")
+				return taskID
+			},
+			wantStatus: http.StatusConflict,
+			wantError:  "already been retried",
+		},
+		{
+			name: "retry with active task on issue rejected",
+			setup: func(t *testing.T) string {
+				issueID := createIssue(t, "active-task-test", "todo")
+				taskID := createTask(t, issueID, "failed")
+				// Create an active (running) task on the same issue
+				activeID := createTask(t, issueID, "running")
+				t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, activeID) })
+				return taskID
+			},
+			wantStatus: http.StatusConflict,
+			wantError:  "active task",
+		},
+		{
+			name: "retry nonexistent task returns 404",
+			setup: func(t *testing.T) string {
+				return "00000000-0000-0000-0000-000000000099"
+			},
+			wantStatus: http.StatusNotFound,
+			wantError:  "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			taskID := tt.setup(t)
+
+			w := httptest.NewRecorder()
+			req := newRequest("POST", "/api/tasks/"+taskID+"/retry", nil)
+			req = withURLParam(req, "taskId", taskID)
+			testHandler.RetryTask(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantError != "" {
+				body := w.Body.String()
+				if !strings.Contains(body, tt.wantError) {
+					t.Fatalf("expected error containing %q, got: %s", tt.wantError, body)
+				}
+				return
+			}
+
+			// Success case: verify the response has a new task with correct lineage.
+			var resp AgentTaskResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.ID == "" || resp.ID == taskID {
+				t.Fatal("expected new task ID, got same or empty")
+			}
+			if resp.Status != "queued" {
+				t.Fatalf("expected status 'queued', got %q", resp.Status)
+			}
+			if resp.RetriedFromID == nil || *resp.RetriedFromID != taskID {
+				t.Fatalf("expected retried_from_id = %q, got %v", taskID, resp.RetriedFromID)
+			}
+
+			// Cleanup: the retry task itself
+			t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, resp.ID) })
+		})
+	}
+}
+

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -26,7 +26,7 @@ var (
 	ErrTaskNotRetryable = errors.New("task is not retryable: only failed or cancelled tasks can be retried")
 	ErrAlreadyRetried  = errors.New("task has already been retried")
 	ErrActiveTaskExists = errors.New("an active task already exists for this issue")
-	ErrIssueClosed     = errors.New("cannot retry: issue is closed")
+	ErrIssueClosed     = errors.New("cannot retry: issue is done")
 )
 
 type TaskService struct {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -20,6 +20,15 @@ import (
 	"github.com/multica-ai/multica/server/pkg/redact"
 )
 
+// Sentinel errors for RetryTask.
+var (
+	ErrTaskNotFound    = errors.New("task not found")
+	ErrTaskNotRetryable = errors.New("task is not retryable: only failed or cancelled tasks can be retried")
+	ErrAlreadyRetried  = errors.New("task has already been retried")
+	ErrActiveTaskExists = errors.New("an active task already exists for this issue")
+	ErrIssueClosed     = errors.New("cannot retry: issue is closed")
+)
+
 type TaskService struct {
 	Queries *db.Queries
 	Hub     *realtime.Hub
@@ -174,6 +183,77 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 
 	return &task, nil
+}
+
+// RetryTask creates a new queued task as a retry of a failed or cancelled task.
+// Guards: task must be failed/cancelled, not already retried, no active task
+// on the same issue, and the issue must not be closed/done.
+func (s *TaskService) RetryTask(ctx context.Context, taskID pgtype.UUID, workspaceID string) (*db.AgentTaskQueue, error) {
+	// Load the original task.
+	original, err := s.Queries.GetAgentTask(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, fmt.Errorf("get task: %w", err)
+	}
+
+	// Only failed or cancelled tasks can be retried.
+	if original.Status != "failed" && original.Status != "cancelled" {
+		return nil, ErrTaskNotRetryable
+	}
+
+	// Guard: this task must not have been retried already.
+	hasRetry, err := s.Queries.HasRetryTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("check retry: %w", err)
+	}
+	if hasRetry {
+		return nil, ErrAlreadyRetried
+	}
+
+	// Guard: no active task on the same issue.
+	if original.IssueID.Valid {
+		hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, original.IssueID)
+		if err != nil {
+			return nil, fmt.Errorf("check active task: %w", err)
+		}
+		if hasActive {
+			return nil, ErrActiveTaskExists
+		}
+
+		// Guard: issue must not be closed/done.
+		issue, err := s.Queries.GetIssue(ctx, original.IssueID)
+		if err != nil {
+			return nil, fmt.Errorf("get issue: %w", err)
+		}
+		if issue.Status == "done" || issue.Status == "closed" {
+			return nil, ErrIssueClosed
+		}
+
+		// Verify issue belongs to the expected workspace.
+		if util.UUIDToString(issue.WorkspaceID) != workspaceID {
+			return nil, ErrTaskNotFound
+		}
+	}
+
+	// Create the retry task.
+	newTask, err := s.Queries.CreateRetryTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("create retry task: %w", err)
+	}
+
+	slog.Info("task retried",
+		"original_task_id", util.UUIDToString(taskID),
+		"new_task_id", util.UUIDToString(newTask.ID),
+		"issue_id", util.UUIDToString(newTask.IssueID),
+		"agent_id", util.UUIDToString(newTask.AgentID),
+	)
+
+	// Broadcast task:dispatch so frontends show the new live card.
+	s.broadcastTaskDispatch(ctx, newTask)
+
+	return &newTask, nil
 }
 
 // ClaimTask atomically claims the next queued task for an agent,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -212,29 +212,32 @@ func (s *TaskService) RetryTask(ctx context.Context, taskID pgtype.UUID, workspa
 		return nil, ErrAlreadyRetried
 	}
 
+	// Retry is only supported for issue tasks (chat has its own "send again" flow).
+	if !original.IssueID.Valid {
+		return nil, ErrTaskNotRetryable
+	}
+
 	// Guard: no active task on the same issue.
-	if original.IssueID.Valid {
-		hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, original.IssueID)
-		if err != nil {
-			return nil, fmt.Errorf("check active task: %w", err)
-		}
-		if hasActive {
-			return nil, ErrActiveTaskExists
-		}
+	hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, original.IssueID)
+	if err != nil {
+		return nil, fmt.Errorf("check active task: %w", err)
+	}
+	if hasActive {
+		return nil, ErrActiveTaskExists
+	}
 
-		// Guard: issue must not be closed/done.
-		issue, err := s.Queries.GetIssue(ctx, original.IssueID)
-		if err != nil {
-			return nil, fmt.Errorf("get issue: %w", err)
-		}
-		if issue.Status == "done" || issue.Status == "closed" {
-			return nil, ErrIssueClosed
-		}
+	// Guard: issue must not be closed/done.
+	issue, err := s.Queries.GetIssue(ctx, original.IssueID)
+	if err != nil {
+		return nil, fmt.Errorf("get issue: %w", err)
+	}
+	if issue.Status == "done" || issue.Status == "closed" {
+		return nil, ErrIssueClosed
+	}
 
-		// Verify issue belongs to the expected workspace.
-		if util.UUIDToString(issue.WorkspaceID) != workspaceID {
-			return nil, ErrTaskNotFound
-		}
+	// Verify issue belongs to the expected workspace.
+	if util.UUIDToString(issue.WorkspaceID) != workspaceID {
+		return nil, ErrTaskNotFound
 	}
 
 	// Create the retry task.

--- a/server/migrations/040_task_retry_lineage.down.sql
+++ b/server/migrations/040_task_retry_lineage.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_agent_task_queue_retried_from;
+ALTER TABLE agent_task_queue DROP COLUMN IF EXISTS retried_from_id;

--- a/server/migrations/040_task_retry_lineage.up.sql
+++ b/server/migrations/040_task_retry_lineage.up.sql
@@ -1,0 +1,6 @@
+-- Add retry lineage tracking to agent_task_queue.
+-- retried_from_id points to the original failed/cancelled task that was retried.
+ALTER TABLE agent_task_queue ADD COLUMN retried_from_id UUID REFERENCES agent_task_queue(id);
+
+-- Index for the double-retry guard: "has this task already been retried?"
+CREATE INDEX idx_agent_task_queue_retried_from ON agent_task_queue(retried_from_id) WHERE retried_from_id IS NOT NULL;

--- a/server/migrations/041_retry_unique_index.down.sql
+++ b/server/migrations/041_retry_unique_index.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_agent_task_queue_retried_from;
+CREATE INDEX idx_agent_task_queue_retried_from ON agent_task_queue(retried_from_id) WHERE retried_from_id IS NOT NULL;

--- a/server/migrations/041_retry_unique_index.up.sql
+++ b/server/migrations/041_retry_unique_index.up.sql
@@ -1,0 +1,3 @@
+-- Enforce single retry per task at the DB level (prevents race conditions).
+DROP INDEX IF EXISTS idx_agent_task_queue_retried_from;
+CREATE UNIQUE INDEX idx_agent_task_queue_retried_from ON agent_task_queue(retried_from_id) WHERE retried_from_id IS NOT NULL;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -624,7 +624,7 @@ func (q *Queries) HasRetryTask(ctx context.Context, retriedFromID pgtype.UUID) (
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running')
 ORDER BY created_at DESC
 `
 

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -51,7 +51,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -75,6 +75,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -120,7 +121,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 // Claims the next queued task for an agent, enforcing per-(issue, agent) serialization:
@@ -149,6 +150,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -157,7 +159,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 type CompleteAgentTaskParams struct {
@@ -193,6 +195,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -272,7 +275,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 const createAgentTask = `-- name: CreateAgentTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
 VALUES ($1, $2, $3, 'queued', $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 type CreateAgentTaskParams struct {
@@ -310,6 +313,43 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
+	)
+	return i, err
+}
+
+const createRetryTask = `-- name: CreateRetryTask :one
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, retried_from_id)
+SELECT t.agent_id, t.runtime_id, t.issue_id, 'queued', t.priority, t.trigger_comment_id, t.id
+FROM agent_task_queue t
+WHERE t.id = $1
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
+`
+
+// Creates a new queued task as a retry of a failed/cancelled task.
+// Copies agent_id, runtime_id, issue_id, and trigger_comment_id from the original.
+func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, createRetryTask, id)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -318,7 +358,7 @@ const failAgentTask = `-- name: FailAgentTask :one
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = $2
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 type FailAgentTaskParams struct {
@@ -347,6 +387,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -459,7 +500,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -484,6 +525,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }
@@ -507,6 +549,10 @@ type GetLastTaskSessionRow struct {
 
 // Returns the session_id and work_dir from the most recent completed task
 // for a given (agent_id, issue_id) pair, used for session resumption.
+// INTENTIONAL: only completed tasks are eligible. Do NOT add failed/cancelled
+// here — resuming a failed session re-loads broken context (hallucination
+// loops, bad tool state) and the agent will likely fail again. Fresh starts
+// on failure is a deliberate safety rail.
 func (q *Queries) GetLastTaskSession(ctx context.Context, arg GetLastTaskSessionParams) (GetLastTaskSessionRow, error) {
 	row := q.db.QueryRow(ctx, getLastTaskSession, arg.AgentID, arg.IssueID)
 	var i GetLastTaskSessionRow
@@ -562,8 +608,22 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 	return has_pending, err
 }
 
+const hasRetryTask = `-- name: HasRetryTask :one
+SELECT count(*) > 0 AS has_retry FROM agent_task_queue
+WHERE retried_from_id = $1
+`
+
+// Returns true if a retry task already exists for the given original task.
+// Used as double-retry guard.
+func (q *Queries) HasRetryTask(ctx context.Context, retriedFromID pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, hasRetryTask, retriedFromID)
+	var has_retry bool
+	err := row.Scan(&has_retry)
+	return has_retry, err
+}
+
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC
 `
@@ -595,6 +655,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ChatSessionID,
+			&i.RetriedFromID,
 		); err != nil {
 			return nil, err
 		}
@@ -607,7 +668,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -639,6 +700,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ChatSessionID,
+			&i.RetriedFromID,
 		); err != nil {
 			return nil, err
 		}
@@ -739,7 +801,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -771,6 +833,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ChatSessionID,
+			&i.RetriedFromID,
 		); err != nil {
 			return nil, err
 		}
@@ -783,7 +846,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -815,6 +878,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ChatSessionID,
+			&i.RetriedFromID,
 		); err != nil {
 			return nil, err
 		}
@@ -861,7 +925,7 @@ const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -885,6 +949,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 const createChatTask = `-- name: CreateChatTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, chat_session_id)
 VALUES ($1, $2, NULL, 'queued', $3, $4)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, retried_from_id
 `
 
 type CreateChatTaskParams struct {
@@ -128,6 +128,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ChatSessionID,
+		&i.RetriedFromID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -79,6 +79,7 @@ type AgentTaskQueue struct {
 	WorkDir          pgtype.Text        `json:"work_dir"`
 	TriggerCommentID pgtype.UUID        `json:"trigger_comment_id"`
 	ChatSessionID    pgtype.UUID        `json:"chat_session_id"`
+	RetriedFromID    pgtype.UUID        `json:"retried_from_id"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -176,7 +176,7 @@ ORDER BY priority DESC, created_at ASC;
 
 -- name: ListActiveTasksByIssue :many
 SELECT * FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running')
 ORDER BY created_at DESC;
 
 -- name: ListTasksByIssue :many

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -115,6 +115,10 @@ RETURNING *;
 -- name: GetLastTaskSession :one
 -- Returns the session_id and work_dir from the most recent completed task
 -- for a given (agent_id, issue_id) pair, used for session resumption.
+-- INTENTIONAL: only completed tasks are eligible. Do NOT add failed/cancelled
+-- here — resuming a failed session re-loads broken context (hallucination
+-- loops, bad tool state) and the agent will likely fail again. Fresh starts
+-- on failure is a deliberate safety rail.
 SELECT session_id, work_dir FROM agent_task_queue
 WHERE agent_id = $1 AND issue_id = $2 AND status = 'completed' AND session_id IS NOT NULL
 ORDER BY completed_at DESC
@@ -179,6 +183,21 @@ ORDER BY created_at DESC;
 SELECT * FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC;
+
+-- name: CreateRetryTask :one
+-- Creates a new queued task as a retry of a failed/cancelled task.
+-- Copies agent_id, runtime_id, issue_id, and trigger_comment_id from the original.
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, retried_from_id)
+SELECT t.agent_id, t.runtime_id, t.issue_id, 'queued', t.priority, t.trigger_comment_id, t.id
+FROM agent_task_queue t
+WHERE t.id = $1
+RETURNING *;
+
+-- name: HasRetryTask :one
+-- Returns true if a retry task already exists for the given original task.
+-- Used as double-retry guard.
+SELECT count(*) > 0 AS has_retry FROM agent_task_queue
+WHERE retried_from_id = $1;
 
 -- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()


### PR DESCRIPTION
## Summary

- **One-click retry button** on failed and cancelled agent tasks in execution history
- `POST /api/tasks/{taskId}/retry` endpoint with guards (double-retry, active task, closed issue, workspace ownership)
- `retried_from_id` column for retry lineage tracking
- Live card appears immediately after retry (queued tasks included in active task query)
- Button states: visible → spinner "Retrying..." → hidden on success / reverts on failure
- Hidden entirely when active task exists (not dimmed)
- User-friendly toast messages for error cases
- Cross-tab WebSocket sync (retry in tab 1 hides button in tab 2)
- Documents `GetLastTaskSession` safety rail (only completed sessions resume)

### Follow-up issues filed
- #48 — Enrich embedded agent prompt with comments
- #49 — Add cancel/retry events to activity timeline
- #50 — Race: daemon claims task between user cancel and DB update

## Test plan

- [x] 8 data-driven Go handler tests (happy path + all edge cases)
- [x] 9 frontend component tests (visibility, states, toasts, revert)
- [x] ST-1: Retry cancelled task — spinner → live card → button gone
- [x] ST-2: Retry failed task — same flow
- [x] ST-4: Retry hidden while task running
- [x] ST-5: Already-retried task has no button
- [x] ST-6: Retry chain (retry the retry)
- [x] ST-8: Retry on done issue — friendly toast
- [x] ST-10: Multi-tab WebSocket sync
- [x] ST-11: Completed tasks never show retry
- [ ] E2E tests
- [ ] `make check`

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry failed or cancelled tasks from the UI; a Retry button appears in execution history and hides when not applicable
  * Retry actions refresh task history in real time and record retry lineage for auditability
  * Backend prevents retries when an issue is closed or an active task exists

* **Tests**
  * Added end-to-end tests covering retry visibility, workflow, success/failure states, and user-facing errors

* **Chores**
  * Database migrations to track retry lineage and enforce uniqueness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->